### PR TITLE
Fixing two defects:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.microfocus.adm.performancecenter</groupId>
     <artifactId>plugins-common</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Performance Center plugins common</name>

--- a/src/main/java/com/microfocus/adm/performancecenter/plugins/common/pcentities/simplifiedentities/simplifiedtest/content/group/rts/pacing/SimplifiedPacing.java
+++ b/src/main/java/com/microfocus/adm/performancecenter/plugins/common/pcentities/simplifiedentities/simplifiedtest/content/group/rts/pacing/SimplifiedPacing.java
@@ -34,20 +34,20 @@ public class SimplifiedPacing {
         this.delay_random_range = delay_random_range;
     }
 
-    public SimplifiedPacing(int number_of_iterations, SimplifiedPacingTypeValues type, int delay, int delay_random_range) {
-        this.number_of_iterations = number_of_iterations;
-        setType(type);
-        this.delay = delay;
-        this.delay_random_range = delay_random_range;
-    }
+//    public SimplifiedPacing(int number_of_iterations, SimplifiedPacingTypeValues type, int delay, int delay_random_range) {
+//        this.number_of_iterations = number_of_iterations;
+//        setType(type);
+//        this.delay = delay;
+//        this.delay_random_range = delay_random_range;
+//    }
 
     public void setType (String type) {
         this.type = type;
     }
 
-    public void setType (SimplifiedPacingTypeValues type) {
-        this.type = type.value();
-    }
+//    public void setType (SimplifiedPacingTypeValues type) {
+//        this.type = type.value();
+//    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/microfocus/adm/performancecenter/plugins/common/pcentities/simplifiedentities/simplifiedtest/content/group/rts/thinktime/SimplifiedThinkTime.java
+++ b/src/main/java/com/microfocus/adm/performancecenter/plugins/common/pcentities/simplifiedentities/simplifiedtest/content/group/rts/thinktime/SimplifiedThinkTime.java
@@ -24,7 +24,7 @@ public class SimplifiedThinkTime {
     private int multiply_factor;
 
     public SimplifiedThinkTime() {
-        setType(SimplifiedThinkTimeTypeValues.IGNORE);
+        setType(SimplifiedThinkTimeTypeValues.IGNORE.value());
     }
 
     public SimplifiedThinkTime(String type, int min_percentage, int max_percentage, int limit_seconds, int multiply_factor) {
@@ -35,21 +35,21 @@ public class SimplifiedThinkTime {
         this.multiply_factor = multiply_factor;
     }
 
-    public SimplifiedThinkTime(SimplifiedThinkTimeTypeValues type, int min_percentage, int max_percentage, int limit_seconds, int multiply_factor) {
-        setType(type);
-        this.min_percentage = min_percentage;
-        this.max_percentage = max_percentage;
-        this.limit_seconds = limit_seconds;
-        this.multiply_factor = multiply_factor;
-    }
+//    public SimplifiedThinkTime(SimplifiedThinkTimeTypeValues type, int min_percentage, int max_percentage, int limit_seconds, int multiply_factor) {
+//        setType(type);
+//        this.min_percentage = min_percentage;
+//        this.max_percentage = max_percentage;
+//        this.limit_seconds = limit_seconds;
+//        this.multiply_factor = multiply_factor;
+//    }
 
     public void setType(String type) {
         this.type = type;
     }
 
-    public void setType(SimplifiedThinkTimeTypeValues type) {
-        this.type = type.value();
-    }
+//    public void setType(SimplifiedThinkTimeTypeValues type) {
+//        this.type = type.value();
+//    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/microfocus/adm/performancecenter/plugins/common/rest/PcRestProxy.java
+++ b/src/main/java/com/microfocus/adm/performancecenter/plugins/common/rest/PcRestProxy.java
@@ -371,7 +371,8 @@ public class PcRestProxy {
                 return pcScript;
             }
         }
-        return null;
+        throw new PcException(String.format("No script named '%s' was found under this folder path '%s' within the PC project.", scriptName, testFolderPath));
+//        return null;
     }
 
 


### PR DESCRIPTION
-When using this library from jenkins, parsing of TAML fails (apparently because of double signature implemented for a method). Fix: left only one method signature to be available.
-When the value of script_path parameter is incorrect, a NullPointerException failure occurs instead of specifying that the script_path is incorrect. Fix: created an exception explicitly stating that the script could not found and throwing it.